### PR TITLE
Complete the task once all artifacts have been downloaded

### DIFF
--- a/DownloadArtifacts/DownloadArtifacts/download-artifacts/DownloadArtifacts.ps1
+++ b/DownloadArtifacts/DownloadArtifacts/download-artifacts/DownloadArtifacts.ps1
@@ -155,3 +155,4 @@ foreach($buildArtifact in $buildArtifacts.value)
         }
     }
 }
+Write-Host "##vso[task.complete result=Succeeded;]DONE"


### PR DESCRIPTION
Fix for #2 (Task causes flicker in VSTS UI)

Missing `##vso[task.complete result=Succeeded;]` at end of script causes VSTS task not to terminate in the timeline and UI flicker.