### PR TITLE
Use correct help URL

### DIFF
--- a/DownloadArtifacts/DownloadArtifacts/download-artifacts/task.json
+++ b/DownloadArtifacts/DownloadArtifacts/download-artifacts/task.json
@@ -3,7 +3,7 @@
   "name": "download-artifacts",
   "friendlyName": "Download Artifacts",
   "description": "Download build artifacts with filtering by artifact name, when you have more than one artifact, or download sub folders or files, without downloading the entire artifact folder.",
-  "helpMarkDown": "[More Information](https://url.to/yourmarkdown)",
+  "helpMarkDown": "[More Information](https://marketplace.visualstudio.com/items?itemName=chamindac.chamindac-vsts-release-task-download-artifacts)",
   "category": "Utility",
   "visibility": [
     "Release"
@@ -27,7 +27,7 @@
       "label": "Build Artifact Names",
       "defaultValue": "*",
       "required": false,
-      "helpMarkDown": "Artifact Names/Paths to Download separated by ;. Example asterisk (default) as artifat names allow all artifacts download. Multiple artifacts can be specified with pattern Drop1;Drop2. Artifact name with subpath allows to download sub item of a given artifact. Multiple can be specified with pattern Drop1\\MyWebProj;Drop1\\ReleaseNote.html;Drop2;Drop3\\MyWebProj2 . Wild cards in paths are NOT SUPPORTED. Asterisk value as default supported to specify all artifacts."
+      "helpMarkDown": "Artifact Names/Paths to Download separated by ;. Example asterisk (default) as artifact names allow all artifacts download. Multiple artifacts can be specified with pattern Drop1;Drop2. Artifact name with subpath allows to download sub item of a given artifact. Multiple can be specified with pattern Drop1\\MyWebProj;Drop1\\ReleaseNote.html;Drop2;Drop3\\MyWebProj2 . Wild cards in paths are NOT SUPPORTED. Asterisk value as default supported to specify all artifacts."
     },
     {
       "name": "artifactDestinationFolder",


### PR DESCRIPTION
If you press **More Information** in the task, you go to a page with a certificate error:
![image](https://cloud.githubusercontent.com/assets/4221997/24397565/e69c5a48-13a6-11e7-8d9c-7c9ba99d3a62.png)

This PR makes sure you open the page in the marketplace instead.